### PR TITLE
Hanabi improvements 2

### DIFF
--- a/client/src/components/TopBar.tsx
+++ b/client/src/components/TopBar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import * as React from "react";
 import { Game, Player } from "@board-at-home/api/src";
-import { jsx, Input, Flex, Heading, Divider, IconButton } from "theme-ui";
+import { jsx, Input, Flex, Heading, Divider, IconButton, Box } from "theme-ui";
 import { dispatch } from "../model";
 import { setPlayerName } from "../actions";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -63,10 +63,16 @@ const PlayerName = ({ code, player }: { code: string; player: Player }) => {
   }
 
   return (
-    <Flex sx={{ alignItems: "baseline" }}>
-      <div>
+    <Flex sx={{ alignItems: "baseline", maxWidth: "50vw" }}>
+      <Box
+        sx={{
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+        }}
+      >
         Player name: <b>{player.name || player.id}</b>
-      </div>
+      </Box>
       <IconButton onClick={() => setEditing(true)} ml={1}>
         <FontAwesomeIcon icon={faEdit} />
       </IconButton>
@@ -87,6 +93,7 @@ export default ({ game, player }: Props) => (
       <Flex
         sx={{
           alignItems: "baseline",
+          flexWrap: "wrap",
         }}
       >
         <Heading as="h1" mr={2}>
@@ -96,6 +103,6 @@ export default ({ game, player }: Props) => (
       </Flex>
       <PlayerName code={game.code} player={player} />
     </Flex>
-    <Divider mb={3} sx={{ color: "black" }} />
+    <Divider mb={3} sx={{ borderColor: "black" }} />
   </div>
 );

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -87,7 +87,7 @@ export default () => {
   return (
     <Container p={3} sx={{ width: "360px", textAlign: "center" }}>
       <CreateNewGame />
-      <Divider mt={3} mb={3} />
+      <Divider my={3} />
       <JoinGame />
     </Container>
   );

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -32,7 +32,7 @@ const HomePageButton = ({
     disabled={disabled}
     variant={disabled ? "disabled" : "primary"}
     onClick={onClick}
-    sx={{ width: "120px" }}
+    sx={{ width: "110px" }}
   >
     {text}
   </Button>
@@ -85,9 +85,9 @@ const JoinGame = () => {
 
 export default () => {
   return (
-    <Container p={4} sx={{ width: "400px", textAlign: "center" }}>
+    <Container p={3} sx={{ width: "360px", textAlign: "center" }}>
       <CreateNewGame />
-      <Divider mt={4} mb={4} />
+      <Divider mt={3} mb={3} />
       <JoinGame />
     </Container>
   );

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -82,6 +82,13 @@ export default {
       m: 1,
       fontSize: "12px",
     },
+    hanabiDisabled: {
+      color: "white",
+      bg: "#BDBDBD",
+      cursor: "not-allowed",
+      fontSize: "12px",
+      m: 1,
+    },
   },
   forms: {
     input: {

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -81,15 +81,17 @@ export default {
       "&:hover": {
         bg: "#00695C",
       },
+      fontSize: "11px",
       m: 1,
-      fontSize: "12px",
+      p: 2,
     },
     hanabiDisabled: {
       color: "white",
       bg: "#BDBDBD",
       cursor: "not-allowed",
-      fontSize: "12px",
+      fontSize: "11px",
       m: 1,
+      p: 2,
     },
   },
   forms: {

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -5,6 +5,8 @@ import { Theme } from "theme-ui";
 export default {
   ...system,
   fonts: {
+    body: "system-ui, sans-serif",
+    heading: "Georgia, serif",
     fantasy: "pristina",
   },
   colors: {

--- a/games/hanabi/src/api/index.ts
+++ b/games/hanabi/src/api/index.ts
@@ -7,22 +7,22 @@ export interface Config {
   royalFavour: boolean;
 }
 
-export const colours = [
-  "red",
-  "blue",
-  "green",
-  "yellow",
-  "white",
-  "rainbow",
-] as const;
+const colourValues = {
+  red: "red",
+  blue: "blue",
+  green: "green",
+  yellow: "yellow",
+  white: "white",
+  rainbow: "rainbow",
+} as const;
+const colours = Object.values(colourValues);
 export type Colour = typeof colours[number];
+export const getColours = (gameType: GameType): Colour[] =>
+  gameType === "rainbow" ? colours : colours.filter(c => c !== "rainbow");
+
 export const numbers = [1, 2, 3, 4, 5] as const;
 export type Number = typeof numbers[number];
 export const maxCardNum = numbers[numbers.length - 1];
-export const getColours = (gameType: GameType): Colour[] =>
-  gameType === "rainbow"
-    ? colours.slice()
-    : colours.filter(c => c != "rainbow");
 
 export interface Card {
   colour: Colour;

--- a/games/hanabi/src/api/index.ts
+++ b/games/hanabi/src/api/index.ts
@@ -95,13 +95,21 @@ export const noSelectedCards: number[][] = Array.from(
 );
 export const getHandSize = (numPlayers: number) => (numPlayers >= 4 ? 4 : 5);
 
-export const mapToColours = <T>(defaultValue: T): { [key in Colour]: T } => {
+export const mapToColours = <T>(
+  defaultValue: T,
+  gameType: GameType,
+): { [key in Colour]: T } => {
   const piles: { [key: string]: T } = {};
-  colours.map(colour => {
+  const selectedColours = getColours(gameType) || colours;
+  selectedColours.map(colour => {
     piles[colour] = defaultValue;
   });
   return piles as { [key in Colour]: T };
 };
 
-export const emptyPiles: { [key in Colour]: number } = mapToColours(0);
-export const emptyDiscardPile: { [key in Colour]: Card[] } = mapToColours([]);
+export const getEmptyPiles = (
+  gameType: GameType,
+): { [key in Colour]: number } => mapToColours(0, gameType);
+export const getEmptyDiscardPile = (
+  gameType: GameType,
+): { [key in Colour]: Card[] } => mapToColours([], gameType);

--- a/games/hanabi/src/api/index.ts
+++ b/games/hanabi/src/api/index.ts
@@ -113,3 +113,11 @@ export const getEmptyPiles = (
 export const getEmptyDiscardPile = (
   gameType: GameType,
 ): { [key in Colour]: Card[] } => mapToColours([], gameType);
+
+export const hanabiColour = "#00897B";
+export const colourMap = {
+  red: "#E53935",
+  blue: "#039BE5",
+  green: "#66BB6A",
+  yellow: "#FDD835",
+};

--- a/games/hanabi/src/api/index.ts
+++ b/games/hanabi/src/api/index.ts
@@ -8,11 +8,11 @@ export interface Config {
 }
 
 const colourValues = {
-  red: "red",
+  white: "white",
   blue: "blue",
   green: "green",
   yellow: "yellow",
-  white: "white",
+  red: "red",
   rainbow: "rainbow",
 } as const;
 const colours = Object.values(colourValues);

--- a/games/hanabi/src/client/Board/Card.tsx
+++ b/games/hanabi/src/client/Board/Card.tsx
@@ -118,15 +118,18 @@ export const ActionableCard = ({
         </IconButton>
       )}
     </Flex>
-    {canAct && (
-      <Button variant="hanabi" onClick={onPlay} mb={1}>
-        <FontAwesomeIcon icon={faPlay} /> Play
-      </Button>
-    )}
-    {canAct && (
-      <Button variant="hanabi" onClick={onDiscard}>
-        <FontAwesomeIcon icon={faTrash} /> Discard
-      </Button>
-    )}
+    <Button
+      variant={canAct ? "hanabi" : "hanabiDisabled"}
+      onClick={canAct ? onPlay : undefined}
+      mb={1}
+    >
+      <FontAwesomeIcon icon={faPlay} /> Play
+    </Button>
+    <Button
+      variant={canAct ? "hanabi" : "hanabiDisabled"}
+      onClick={canAct ? onDiscard : undefined}
+    >
+      <FontAwesomeIcon icon={faTrash} /> Discard
+    </Button>
   </Flex>
 );

--- a/games/hanabi/src/client/Board/Card.tsx
+++ b/games/hanabi/src/client/Board/Card.tsx
@@ -17,11 +17,10 @@ const commonCardStyles = (selected: boolean): React.CSSProperties => ({
   padding: "15px 10px",
   borderRadius: "4px",
   border: selected ? "1px solid darkgrey" : "1px solid white",
+  transition: "borderColor 100ms ease-in-out",
   minWidth: "41px",
 });
 
-//"linear-gradient(to bottom, blue, blue, green, green, yellow, yellow, orange, red, red, red)",
-//"linear-gradient(to bottom, #039BE5, #039BE5, #66BB6A, #66BB6A, #FDD835, #FDD835, orange, #E53935, #E53935, #E53935)",
 const cardColorStyles = (colour: Colour): React.CSSProperties => {
   if (colour === "rainbow") {
     return {

--- a/games/hanabi/src/client/Board/Card.tsx
+++ b/games/hanabi/src/client/Board/Card.tsx
@@ -17,6 +17,7 @@ const commonCardStyles = (selected: boolean): React.CSSProperties => ({
   padding: "15px 10px",
   borderRadius: "4px",
   border: selected ? "1px solid darkgrey" : "1px solid white",
+  minWidth: "41px",
 });
 
 const colourMap = {

--- a/games/hanabi/src/client/Board/Card.tsx
+++ b/games/hanabi/src/client/Board/Card.tsx
@@ -84,7 +84,7 @@ export const ActionableCard = ({
   onMoveLeft?: () => any;
   onMoveRight?: () => any;
 }) => (
-  <Flex sx={{ flexDirection: "column", width: "100px" }} m={1}>
+  <Flex sx={{ flexDirection: "column", width: "85px" }} m={1}>
     <div
       style={{
         ...commonCardStyles(selected),

--- a/games/hanabi/src/client/Board/Card.tsx
+++ b/games/hanabi/src/client/Board/Card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Card, Colour } from "../../api";
+import { Card, Colour, colourMap } from "../../api";
 import { Flex, IconButton, Button } from "theme-ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -19,13 +19,6 @@ const commonCardStyles = (selected: boolean): React.CSSProperties => ({
   border: selected ? "1px solid darkgrey" : "1px solid white",
   minWidth: "41px",
 });
-
-const colourMap = {
-  red: "#E53935",
-  blue: "#039BE5",
-  green: "#66BB6A",
-  yellow: "#FDD835",
-};
 
 //"linear-gradient(to bottom, blue, blue, green, green, yellow, yellow, orange, red, red, red)",
 //"linear-gradient(to bottom, #039BE5, #039BE5, #66BB6A, #66BB6A, #FDD835, #FDD835, orange, #E53935, #E53935, #E53935)",

--- a/games/hanabi/src/client/Board/Card.tsx
+++ b/games/hanabi/src/client/Board/Card.tsx
@@ -99,14 +99,14 @@ export const ActionableCard = ({
     </div>
     <Flex sx={{ justifyContent: "space-between" }}>
       {onMoveLeft ? (
-        <IconButton onClick={onMoveLeft}>
+        <IconButton onClick={onMoveLeft} title="Swap card to the left">
           <FontAwesomeIcon icon={faArrowLeft} style={{ margin: "5px" }} />
         </IconButton>
       ) : (
         <div />
       )}
       {onMoveRight && (
-        <IconButton onClick={onMoveRight}>
+        <IconButton onClick={onMoveRight} title="Swap card to the right">
           <FontAwesomeIcon icon={faArrowRight} style={{ margin: "5px" }} />
         </IconButton>
       )}

--- a/games/hanabi/src/client/Board/Hands.tsx
+++ b/games/hanabi/src/client/Board/Hands.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Button, Flex } from "theme-ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { faInfoCircle, faUser } from "@fortawesome/free-solid-svg-icons";
 import * as _ from "lodash";
 import { ActionableCard, CardDisplay } from "./Card";
 import { Card, Action } from "../../api";
@@ -13,6 +13,7 @@ export const OtherPlayerHand = ({
   act,
   handIdx,
   name,
+  isCurrentPlayer,
 }: {
   hand: Card[];
   selected: number[];
@@ -20,9 +21,16 @@ export const OtherPlayerHand = ({
   act: (action: Action) => any;
   handIdx: number;
   name: string;
+  isCurrentPlayer: boolean;
 }) => (
-  <Flex sx={{ alignItems: "center" }} key={name}>
-    {name}'s hand:{" "}
+  <Flex sx={{ alignItems: "center" }} key={name} mt={3}>
+    <span
+      style={{ marginRight: "4px", color: isCurrentPlayer ? "#00897B" : "" }}
+    >
+      <FontAwesomeIcon icon={faUser} style={{ marginRight: "4px" }} />
+      {name}
+    </span>
+    's hand:{" "}
     {hand.map((card, cardIdx) => (
       <CardDisplay
         card={card}
@@ -54,7 +62,7 @@ export const ThisPlayerHand = ({
   canGiveInfo: boolean;
 }) => (
   <>
-    <Flex mb={3}>
+    <Flex mb={2}>
       {hand.map((_card, cardIdx) => (
         <ActionableCard
           key={cardIdx}
@@ -90,15 +98,13 @@ export const ThisPlayerHand = ({
         />
       ))}
     </Flex>
-    {canGiveInfo && (
-      <Button
-        variant="hanabi"
-        onClick={() => act({ type: "info" })}
-        mb={4}
-        sx={{ fontSize: "13px" }}
-      >
-        <FontAwesomeIcon icon={faInfoCircle} /> Give information
-      </Button>
-    )}
+    <Button
+      variant={canGiveInfo ? "hanabi" : "hanabiDisabled"}
+      onClick={canGiveInfo ? () => act({ type: "info" }) : undefined}
+      mb={2}
+      sx={{ fontSize: "13px" }}
+    >
+      <FontAwesomeIcon icon={faInfoCircle} /> Give information
+    </Button>
   </>
 );

--- a/games/hanabi/src/client/Board/Hands.tsx
+++ b/games/hanabi/src/client/Board/Hands.tsx
@@ -111,6 +111,7 @@ export const ThisPlayerHand = ({
       onClick={canGiveInfo ? () => act({ type: "info" }) : undefined}
       mb={3}
       sx={{ fontSize: "13px" }}
+      title="If you want to select cards, do it before clicking this, as it will end your turn."
     >
       <FontAwesomeIcon icon={faInfoCircle} /> Give information
     </Button>

--- a/games/hanabi/src/client/Board/Hands.tsx
+++ b/games/hanabi/src/client/Board/Hands.tsx
@@ -23,26 +23,34 @@ export const OtherPlayerHand = ({
   name: string;
   isCurrentPlayer: boolean;
 }) => (
-  <Flex sx={{ alignItems: "center" }} key={name} mt={3}>
-    <span
-      style={{ marginRight: "4px", color: isCurrentPlayer ? "#00897B" : "" }}
-    >
-      <FontAwesomeIcon icon={faUser} style={{ marginRight: "4px" }} />
-      {name}
-    </span>
-    's hand:{" "}
-    {hand.map((card, cardIdx) => (
-      <CardDisplay
-        card={card}
-        key={cardIdx}
-        selected={selected.includes(cardIdx)}
-        onSelect={
-          canAct
-            ? () => act({ type: "select", handIdx: handIdx, cardIdx })
-            : undefined
-        }
-      />
-    ))}
+  <Flex
+    sx={{ alignItems: "center", flexWrap: "wrap", justifyContent: "center" }}
+    key={name}
+    mt={3}
+  >
+    <div>
+      <span
+        style={{ marginRight: "4px", color: isCurrentPlayer ? "#00897B" : "" }}
+      >
+        <FontAwesomeIcon icon={faUser} style={{ marginRight: "4px" }} />
+        {name}
+      </span>
+      's hand:{" "}
+    </div>
+    <Flex>
+      {hand.map((card, cardIdx) => (
+        <CardDisplay
+          card={card}
+          key={cardIdx}
+          selected={selected.includes(cardIdx)}
+          onSelect={
+            canAct
+              ? () => act({ type: "select", handIdx: handIdx, cardIdx })
+              : undefined
+          }
+        />
+      ))}
+    </Flex>
   </Flex>
 );
 
@@ -62,7 +70,7 @@ export const ThisPlayerHand = ({
   canGiveInfo: boolean;
 }) => (
   <>
-    <Flex mb={3}>
+    <Flex mb={3} sx={{ flexWrap: "wrap", justifyContent: "center" }}>
       {hand.map((_card, cardIdx) => (
         <ActionableCard
           key={cardIdx}

--- a/games/hanabi/src/client/Board/Hands.tsx
+++ b/games/hanabi/src/client/Board/Hands.tsx
@@ -62,7 +62,7 @@ export const ThisPlayerHand = ({
   canGiveInfo: boolean;
 }) => (
   <>
-    <Flex mb={2}>
+    <Flex mb={3}>
       {hand.map((_card, cardIdx) => (
         <ActionableCard
           key={cardIdx}
@@ -101,7 +101,7 @@ export const ThisPlayerHand = ({
     <Button
       variant={canGiveInfo ? "hanabi" : "hanabiDisabled"}
       onClick={canGiveInfo ? () => act({ type: "info" }) : undefined}
-      mb={2}
+      mb={3}
       sx={{ fontSize: "13px" }}
     >
       <FontAwesomeIcon icon={faInfoCircle} /> Give information

--- a/games/hanabi/src/client/Board/PlayerMessage.tsx
+++ b/games/hanabi/src/client/Board/PlayerMessage.tsx
@@ -23,5 +23,13 @@ export default ({
   if (currentPlayer.id === playerId) {
     return <div>It's your turn.</div>;
   }
-  return <div>Waiting for {currentPlayer.name || currentPlayer.id}.</div>;
+  return (
+    <div>
+      Waiting for{" "}
+      <span style={{ color: "#00897B" }}>
+        {currentPlayer.name || currentPlayer.id}
+      </span>
+      .
+    </div>
+  );
 };

--- a/games/hanabi/src/client/Board/Table/Tokens.tsx
+++ b/games/hanabi/src/client/Board/Table/Tokens.tsx
@@ -1,7 +1,31 @@
-import * as React from "react";
-import { Box } from "theme-ui";
+/** @jsx jsx */
+import { jsx, Box } from "theme-ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as _ from "lodash";
+import { colourMap, hanabiColour } from "../../../api";
+
+const gainKeyframe = {
+  "0%": {
+    color: "lightgrey",
+  },
+  "50%": {
+    color: hanabiColour,
+  },
+  "100%": {
+    color: "inherit",
+  },
+};
+const loseKeyframe = {
+  "0%": {
+    color: "inherit",
+  },
+  "50%": {
+    color: colourMap["red"],
+  },
+  "100%": {
+    color: "lightgrey",
+  },
+};
 
 export default ({
   num,
@@ -11,22 +35,43 @@ export default ({
   num: number;
   total: number;
   icon: any;
-}) => (
-  <Box m={1}>
-    {_.range(num).map(idx => (
-      <FontAwesomeIcon
-        key={`have_${idx}`}
-        icon={icon}
-        style={{ margin: "5px" }}
-      />
-    ))}
-    {_.range(total - num).map(idx => (
-      <FontAwesomeIcon
-        icon={icon}
-        key={`used_${idx}`}
-        style={{ margin: "5px" }}
-        color="lightgrey"
-      />
-    ))}
-  </Box>
-);
+}) => {
+  const tokens = _.range(num);
+  const missing = _.range(total - num).reverse();
+
+  return (
+    <Box m={1}>
+      {tokens.map(idx => (
+        <FontAwesomeIcon
+          key={`have_${idx}`}
+          icon={icon}
+          style={{ margin: "5px" }}
+          css={{
+            WebkitAnimation: "gain 1s forwards",
+            animation: "gain 1s forwards",
+            "@webkit-keyframes gain": gainKeyframe,
+            "@keyframes gain": gainKeyframe,
+          }}
+        />
+      ))}
+      {missing.map(idx => (
+        <span
+          key={`used_${idx}`}
+          css={{
+            WebkitAnimation: "lose 1s forwards",
+            animation: "lose 1s forwards",
+            "@webkit-keyframes lose": loseKeyframe,
+            "@keyframes lose": loseKeyframe,
+          }}
+        >
+          <FontAwesomeIcon
+            icon={icon}
+            style={{
+              margin: "5px",
+            }}
+          />
+        </span>
+      ))}
+    </Box>
+  );
+};

--- a/games/hanabi/src/client/Board/Table/index.tsx
+++ b/games/hanabi/src/client/Board/Table/index.tsx
@@ -27,8 +27,8 @@ export default ({ game }: { game: StartedGame<State, Config> }) => {
         borderRadius: "4px",
         width: "320px",
       }}
-      ml={3}
       p={3}
+      m={1}
     >
       <Flex sx={{ height: CARD_HEIGHT }}>
         {(Object.keys(

--- a/games/hanabi/src/client/Board/Table/index.tsx
+++ b/games/hanabi/src/client/Board/Table/index.tsx
@@ -19,7 +19,7 @@ export default ({ game }: { game: StartedGame<State, Config> }) => {
   // (in which case rethink data structure/org)
   const discarded = _.flatten(
     Object.values(game.state.board.discardPile).map(colour =>
-      _.sortBy(colour).reverse(),
+      _.sortBy(colour, c => c.num).reverse(),
     ),
   );
 

--- a/games/hanabi/src/client/Board/Table/index.tsx
+++ b/games/hanabi/src/client/Board/Table/index.tsx
@@ -15,13 +15,7 @@ import * as _ from "lodash";
 const CARD_HEIGHT = "72px";
 
 export default ({ game }: { game: StartedGame<State, Config> }) => {
-  // Currently displaying as a somewhat organized list, may reconsider
-  // (in which case rethink data structure/org)
-  const discarded = _.flatten(
-    Object.values(game.state.board.discardPile).map(colour =>
-      _.sortBy(colour, c => c.num).reverse(),
-    ),
-  );
+  const discarded = _.flatten(Object.values(game.state.board.discardPile));
 
   return (
     <Flex
@@ -67,13 +61,22 @@ export default ({ game }: { game: StartedGame<State, Config> }) => {
       <Flex
         sx={{
           minHeight: CARD_HEIGHT,
+          flexDirection: "column",
           alignItems: "center",
-          flexWrap: "wrap",
         }}
         m={2}
       >
-        {discarded.map((card, idx) => (
-          <CardDisplay card={card} key={idx} selected={false} />
+        {Object.values(game.state.board.discardPile).map((pile, pileIdx) => (
+          <Flex
+            sx={{
+              flexWrap: "wrap",
+            }}
+            key={pileIdx}
+          >
+            {pile.map((card, idx) => (
+              <CardDisplay card={card} key={idx} selected={false} />
+            ))}
+          </Flex>
         ))}
       </Flex>
     </Flex>

--- a/games/hanabi/src/client/Board/Table/index.tsx
+++ b/games/hanabi/src/client/Board/Table/index.tsx
@@ -15,6 +15,7 @@ import * as _ from "lodash";
 const CARD_HEIGHT = "72px";
 
 export default ({ game }: { game: StartedGame<State, Config> }) => {
+  // TODO: try discard in columns? or reorg so it doesn't move unexpectedly?
   const discarded = _.flatten(Object.values(game.state.board.discardPile));
 
   return (

--- a/games/hanabi/src/client/Board/Table/index.tsx
+++ b/games/hanabi/src/client/Board/Table/index.tsx
@@ -15,7 +15,6 @@ import * as _ from "lodash";
 const CARD_HEIGHT = "72px";
 
 export default ({ game }: { game: StartedGame<State, Config> }) => {
-  // TODO: try discard in columns? or reorg so it doesn't move unexpectedly?
   const discarded = _.flatten(Object.values(game.state.board.discardPile));
 
   return (
@@ -57,19 +56,19 @@ export default ({ game }: { game: StartedGame<State, Config> }) => {
         icon={faBomb}
       />
       {discarded.length > 0 && (
-        <FontAwesomeIcon icon={faTrash} style={{ marginTop: "8px" }} />
+        <FontAwesomeIcon icon={faTrash} style={{ marginTop: "16px" }} />
       )}
       <Flex
         sx={{
           minHeight: CARD_HEIGHT,
-          flexDirection: "column",
-          alignItems: "center",
+          alignItems: "start",
         }}
         m={2}
       >
         {Object.values(game.state.board.discardPile).map((pile, pileIdx) => (
           <Flex
             sx={{
+              flexDirection: "column",
               flexWrap: "wrap",
             }}
             key={pileIdx}

--- a/games/hanabi/src/client/Board/index.tsx
+++ b/games/hanabi/src/client/Board/index.tsx
@@ -7,6 +7,8 @@ import Table from "./Table";
 import { ThisPlayerHand, OtherPlayerHand } from "./Hands";
 import PlayerMessage from "./PlayerMessage";
 
+// TODO: mobile friendly?
+// TODO: animations, highlight token and card changes
 export const Board = ({
   game,
   playerId,
@@ -21,7 +23,10 @@ export const Board = ({
     game.state.board.infoTokens > 0;
 
   return (
-    <Flex className="board" sx={{ width: "100%", justifyContent: "center" }}>
+    <Flex
+      className="board"
+      sx={{ width: "100%", justifyContent: "center", flexWrap: "wrap" }}
+    >
       <Flex
         sx={{
           flexDirection: "column",
@@ -42,21 +47,29 @@ export const Board = ({
           finished={game.state.finished}
           piles={game.state.board.piles}
         />
-        {Object.keys(game.players).map((id, idx) =>
-          id != playerId ? (
-            <OtherPlayerHand
-              hand={game.state.board.hands[idx]}
-              selected={game.state.selectedCards[idx]}
-              canAct={canAct}
-              act={act}
-              name={game.players[id].name || game.players[id].id}
-              handIdx={idx}
-              isCurrentPlayer={game.state.currentPlayer === idx}
-            />
-          ) : (
-            <div key={id} />
-          ),
-        )}
+        <Flex
+          sx={{
+            flexDirection: "column",
+            alignItems: "flex-end",
+          }}
+          mb={3}
+        >
+          {Object.keys(game.players).map((id, idx) =>
+            id != playerId ? (
+              <OtherPlayerHand
+                hand={game.state.board.hands[idx]}
+                selected={game.state.selectedCards[idx]}
+                canAct={canAct}
+                act={act}
+                name={game.players[id].name || game.players[id].id}
+                handIdx={idx}
+                isCurrentPlayer={game.state.currentPlayer === idx}
+              />
+            ) : (
+              <div key={id} />
+            ),
+          )}
+        </Flex>
       </Flex>
       <Table game={game} />
     </Flex>

--- a/games/hanabi/src/client/Board/index.tsx
+++ b/games/hanabi/src/client/Board/index.tsx
@@ -7,7 +7,7 @@ import Table from "./Table";
 import { ThisPlayerHand, OtherPlayerHand } from "./Hands";
 import PlayerMessage from "./PlayerMessage";
 
-// TODO: animations, highlight token and card changes
+// TODO: animations, highlight card changes
 export const Board = ({
   game,
   playerId,

--- a/games/hanabi/src/client/Board/index.tsx
+++ b/games/hanabi/src/client/Board/index.tsx
@@ -8,6 +8,11 @@ import { ThisPlayerHand, OtherPlayerHand } from "./Hands";
 import PlayerMessage from "./PlayerMessage";
 
 // TODO: animations, highlight card changes
+// flip on play/discard
+// then highlight/slide in to table piles
+// slide away from deck when drawing
+// and slide into place in hand in on draw
+// swap on move (easier if we assume big screen...)
 export const Board = ({
   game,
   playerId,

--- a/games/hanabi/src/client/Board/index.tsx
+++ b/games/hanabi/src/client/Board/index.tsx
@@ -28,12 +28,6 @@ export const Board = ({
           alignItems: "center",
         }}
       >
-        <PlayerMessage
-          playerId={playerId}
-          currentPlayer={Object.values(game.players)[game.state.currentPlayer]}
-          finished={game.state.finished}
-          piles={game.state.board.piles}
-        />
         <ThisPlayerHand
           hand={game.state.board.hands[playerIdx]}
           selected={game.state.selectedCards[playerIdx]}
@@ -41,6 +35,12 @@ export const Board = ({
           canGiveInfo={canGiveInfo}
           act={act}
           handIdx={playerIdx}
+        />
+        <PlayerMessage
+          playerId={playerId}
+          currentPlayer={Object.values(game.players)[game.state.currentPlayer]}
+          finished={game.state.finished}
+          piles={game.state.board.piles}
         />
         {Object.keys(game.players).map((id, idx) =>
           id != playerId ? (
@@ -51,6 +51,7 @@ export const Board = ({
               act={act}
               name={game.players[id].name || game.players[id].id}
               handIdx={idx}
+              isCurrentPlayer={game.state.currentPlayer === idx}
             />
           ) : (
             <div key={id} />

--- a/games/hanabi/src/client/Board/index.tsx
+++ b/games/hanabi/src/client/Board/index.tsx
@@ -7,7 +7,6 @@ import Table from "./Table";
 import { ThisPlayerHand, OtherPlayerHand } from "./Hands";
 import PlayerMessage from "./PlayerMessage";
 
-// TODO: mobile friendly?
 // TODO: animations, highlight token and card changes
 export const Board = ({
   game,

--- a/games/hanabi/src/client/ConfigPanel.tsx
+++ b/games/hanabi/src/client/ConfigPanel.tsx
@@ -26,9 +26,9 @@ export const ConfigPanel = ({ config, setConfig }: ConfigProps<Config>) => (
         checked={config.royalFavour}
         onChange={() => setConfig({ royalFavour: !config.royalFavour })}
       />
-      Royal Favour (complete all sets)
+      Royal Favour (finish all sets)
     </Label>
-    <Label sx={{ alignItems: "center", width: "auto" }}>
+    <Label sx={{ alignItems: "center", width: "170px" }}>
       <Input
         type="number"
         min="1"
@@ -42,7 +42,7 @@ export const ConfigPanel = ({ config, setConfig }: ConfigProps<Config>) => (
       <FontAwesomeIcon icon={faInfoCircle} style={{ margin: "5px" }} />
       info tokens
     </Label>
-    <Label sx={{ alignItems: "center", width: "auto" }}>
+    <Label sx={{ alignItems: "center", width: "170px" }}>
       <Input
         type="number"
         min="1"

--- a/games/hanabi/src/engine/actions.ts
+++ b/games/hanabi/src/engine/actions.ts
@@ -14,10 +14,10 @@ export const removeInfoToken = (state: State) => {
   state.board.infoTokens -= 1;
 };
 
-export const drawCard = (state: State) => {
+export const drawCard = (state: State, cardIdx: number) => {
   const drawnCard = state.board.deck.shift();
   if (drawnCard) {
-    state.board.hands[state.currentPlayer].push(drawnCard);
+    state.board.hands[state.currentPlayer].splice(cardIdx, 0, drawnCard);
   }
 };
 
@@ -83,7 +83,7 @@ export const playCard = (
     state.board.discardPile[card.colour].push(card);
     state.board.fuseTokens -= 1;
   }
-  drawCard(state);
+  drawCard(state, cardIdx);
 };
 
 export const discardCard = (
@@ -98,7 +98,7 @@ export const discardCard = (
     card,
   );
   addInfoToken(state, maxInfoTokens);
-  drawCard(state);
+  drawCard(state, cardIdx);
 };
 
 export const advancePlayer = (

--- a/games/hanabi/src/engine/actions.ts
+++ b/games/hanabi/src/engine/actions.ts
@@ -93,7 +93,11 @@ export const discardCard = (
 ) => {
   const card = state.board.hands[state.currentPlayer].splice(cardIdx, 1)[0];
   state.board.discardPile[card.colour].splice(
-    _.sortedIndexBy(state.board.discardPile[card.colour], card, "num"),
+    _.sortedIndexBy(
+      state.board.discardPile[card.colour],
+      card,
+      card => -card.num,
+    ),
     0,
     card,
   );

--- a/games/hanabi/src/engine/actions.ts
+++ b/games/hanabi/src/engine/actions.ts
@@ -1,4 +1,5 @@
 import { State, noSelectedCards, maxCardNum } from "../api";
+import * as _ from "lodash";
 
 export const addInfoToken = (state: State, maxInfoTokens: number) => {
   if (state.board.infoTokens < maxInfoTokens) {
@@ -91,7 +92,11 @@ export const discardCard = (
   maxInfoTokens: number,
 ) => {
   const card = state.board.hands[state.currentPlayer].splice(cardIdx, 1)[0];
-  state.board.discardPile[card.colour].push(card);
+  state.board.discardPile[card.colour].splice(
+    _.sortedIndexBy(state.board.discardPile[card.colour], card, "num"),
+    0,
+    card,
+  );
   addInfoToken(state, maxInfoTokens);
   drawCard(state);
 };

--- a/games/hanabi/src/engine/board.ts
+++ b/games/hanabi/src/engine/board.ts
@@ -2,8 +2,8 @@ import {
   Board,
   maxCardNum,
   Card,
-  emptyPiles,
-  emptyDiscardPile,
+  getEmptyPiles,
+  getEmptyDiscardPile,
   Config,
 } from "../api";
 import { cannotCompleteEverySet, createDeck, deal } from "./deck";
@@ -12,8 +12,8 @@ import * as _ from "lodash";
 export const getInitialBoard = (numPlayers: number, config: Config): Board => {
   const deck: Card[] = createDeck(config.gameType);
   return {
-    piles: emptyPiles,
-    discardPile: emptyDiscardPile,
+    piles: getEmptyPiles(config.gameType),
+    discardPile: getEmptyDiscardPile(config.gameType),
     deck,
     hands: deal(deck, numPlayers),
     infoTokens: config.infoTokens,

--- a/games/hanabi/test/api.test.ts
+++ b/games/hanabi/test/api.test.ts
@@ -1,4 +1,11 @@
-import { getHandSize } from "../src/api";
+import {
+  getHandSize,
+  getEmptyDiscardPile,
+  getEmptyPiles,
+  mapToColours,
+  getColours,
+} from "../src/api";
+import * as _ from "lodash";
 
 describe("getHandSize", () => {
   it("Returns 5 for 2 or 3 players", () => {
@@ -8,5 +15,49 @@ describe("getHandSize", () => {
   it("Returns 4 for 4 or 5 players", () => {
     expect(getHandSize(4)).toBe(4);
     expect(getHandSize(5)).toBe(4);
+  });
+});
+
+const basicColours = getColours("basic");
+const rainbowColours = getColours("rainbow");
+
+describe("mapToColours", () => {
+  it("Maps a value to keys of basic colours", () => {
+    const value = 1;
+    const res = mapToColours(value, "basic");
+    expect(Object.keys(res)).toHaveLength(basicColours.length);
+    expect(_.every(Object.values(res), val => val === value)).toBeTruthy;
+  });
+  it("Maps a value to keys of colours including rainbow", () => {
+    const value = 2;
+    const res = mapToColours(value, "rainbow");
+    expect(Object.keys(res)).toHaveLength(rainbowColours.length);
+    expect(_.every(Object.values(res), val => val === value)).toBeTruthy;
+  });
+});
+
+describe("getEmptyPiles", () => {
+  it("Creates basic empty piles", () => {
+    const piles = getEmptyPiles("basic");
+    expect(Object.keys(piles)).toHaveLength(basicColours.length);
+    expect(piles["red"]).toEqual(0);
+  });
+  it("Creates rainbow empty piles", () => {
+    const piles = getEmptyPiles("rainbow");
+    expect(Object.keys(piles)).toHaveLength(rainbowColours.length);
+    expect(piles["rainbow"]).toEqual(0);
+  });
+});
+
+describe("getEmptyDiscardPile", () => {
+  it("Creates basic empty discard piles", () => {
+    const piles = getEmptyDiscardPile("basic");
+    expect(Object.keys(piles)).toHaveLength(basicColours.length);
+    expect(piles["red"]).toEqual([]);
+  });
+  it("Creates rainbow empty discard piles", () => {
+    const piles = getEmptyDiscardPile("rainbow");
+    expect(Object.keys(piles)).toHaveLength(rainbowColours.length);
+    expect(piles["rainbow"]).toEqual([]);
   });
 });

--- a/games/hanabi/test/engine/actions.test.ts
+++ b/games/hanabi/test/engine/actions.test.ts
@@ -30,12 +30,12 @@ describe("addInfoToken", () => {
       board: { infoTokens: defaultConfig.infoTokens - 1, ...startState.board },
     };
     addInfoToken(testState, defaultConfig.infoTokens);
-    expect(testState.board.infoTokens === defaultConfig.infoTokens);
+    expect(testState.board.infoTokens).toEqual(defaultConfig.infoTokens);
   });
   it("Does not increase when info tokens are full", () => {
     const testState = { ...startState };
     addInfoToken(testState, defaultConfig.infoTokens);
-    expect(testState.board.infoTokens === defaultConfig.infoTokens);
+    expect(testState.board.infoTokens).toEqual(defaultConfig.infoTokens);
   });
 });
 
@@ -43,15 +43,14 @@ describe("removeInfoToken", () => {
   it("Decreases the number of info tokens by one when not empty", () => {
     const testState = { ...startState };
     removeInfoToken(testState);
-    expect(testState.board.infoTokens === defaultConfig.infoTokens - 1);
+    expect(testState.board.infoTokens).toEqual(defaultConfig.infoTokens - 1);
   });
   it("Does not decrease when info tokens are empty", () => {
     const testState = {
       ...startState,
-      board: { infoTokens: 0, ...startState.board },
+      board: { ...startState.board, infoTokens: 0 },
     };
-    removeInfoToken(testState);
-    expect(testState.board.infoTokens === 0);
+    expect(() => removeInfoToken(testState)).toThrow();
   });
 });
 
@@ -62,12 +61,12 @@ describe("drawCard", () => {
     const prevHandSize = testState.board.hands[testState.currentPlayer].length;
     const topCard = testState.board.deck[0];
     drawCard(testState);
-    expect(testState.board.deck.length).toBe(prevDeckSize - 1);
+    expect(testState.board.deck).toHaveLength(prevDeckSize - 1);
     const newHandSize = testState.board.hands[testState.currentPlayer].length;
-    expect(newHandSize).toBe(prevHandSize + 1);
+    expect(newHandSize).toEqual(prevHandSize + 1);
     expect(
       testState.board.hands[testState.currentPlayer][newHandSize - 1],
-    ).toBe(topCard);
+    ).toEqual(topCard);
   });
   it("Adds nothing when drawing from empty deck", () => {
     const testState = {
@@ -76,12 +75,14 @@ describe("drawCard", () => {
     };
     const prevHandSize = testState.board.hands[testState.currentPlayer].length;
     drawCard(testState);
-    expect(testState.board.deck.length).toBe(0);
+    expect(testState.board.deck.length).toEqual(0);
     const newHandSize = testState.board.hands[testState.currentPlayer].length;
-    expect(newHandSize).toBe(prevHandSize);
+    expect(newHandSize).toEqual(prevHandSize);
     expect(
       testState.board.hands[testState.currentPlayer][newHandSize - 1],
-    ).toBe(startState.board.hands[startState.currentPlayer][prevHandSize - 1]);
+    ).toEqual(
+      startState.board.hands[startState.currentPlayer][prevHandSize - 1],
+    );
   });
 });
 
@@ -196,7 +197,7 @@ describe("playCard", () => {
     };
     testState.board.hands[testState.currentPlayer][cardIdx] = card;
     playCard(testState, cardIdx, defaultConfig.infoTokens);
-    expect(testState.board.piles[card.colour]).toBe(card.num);
+    expect(testState.board.piles[card.colour]).toEqual(card.num);
   });
   it("If invalid, adds card to discard pile from the hand and removes fuse token", () => {
     const card: Card = {
@@ -207,7 +208,7 @@ describe("playCard", () => {
     const prevFuseTokens = testState.board.fuseTokens;
     playCard(testState, cardIdx, defaultConfig.infoTokens);
     expect(testState.board.discardPile[card.colour]).toContain(card);
-    expect(testState.board.fuseTokens).toBe(prevFuseTokens - 1);
+    expect(testState.board.fuseTokens).toEqual(prevFuseTokens - 1);
   });
   it("Adds an info token when completing a stack", () => {
     const prevInfoTokens = 3;
@@ -219,12 +220,12 @@ describe("playCard", () => {
     testState.board.piles[card.colour] = maxCardNum - 1;
     testState.board.hands[testState.currentPlayer][cardIdx] = card;
     playCard(testState, cardIdx, defaultConfig.infoTokens);
-    expect(testState.board.piles[card.colour]).toBe(card.num);
-    expect(testState.board.infoTokens).toBe(prevInfoTokens + 1);
+    expect(testState.board.piles[card.colour]).toEqual(card.num);
+    expect(testState.board.infoTokens).toEqual(prevInfoTokens + 1);
   });
   it("Draws a new card to replenish hand", () => {
     playCard(testState, cardIdx, defaultConfig.infoTokens);
-    expect(testState.board.hands[testState.currentPlayer].length).toBe(
+    expect(testState.board.hands[testState.currentPlayer]).toHaveLength(
       prevHandSize,
     );
   });
@@ -242,10 +243,10 @@ describe("discardCard", () => {
     expect(testState.board.discardPile[card.colour]).toContain(card);
   });
   it("Adds an info token", () => {
-    expect(testState.board.infoTokens).toBe(prevInfoTokens + 1);
+    expect(testState.board.infoTokens).toEqual(prevInfoTokens + 1);
   });
   it("Draws a new card to replenish hand", () => {
-    expect(testState.board.hands[testState.currentPlayer].length).toBe(
+    expect(testState.board.hands[testState.currentPlayer]).toHaveLength(
       prevHandSize,
     );
   });
@@ -259,7 +260,7 @@ describe("advancePlayer", () => {
       defaultConfig.royalFavour,
       testState.board.deck.length,
     );
-    expect(testState.currentPlayer === 1);
+    expect(testState.currentPlayer).toEqual(1);
   });
   it("Wraps to first player after last player", () => {
     const testState = {
@@ -271,7 +272,7 @@ describe("advancePlayer", () => {
       defaultConfig.royalFavour,
       testState.board.deck.length,
     );
-    expect(testState.currentPlayer === 0);
+    expect(testState.currentPlayer).toEqual(0);
   });
   it("Resets selection", () => {
     const testState = {
@@ -292,7 +293,7 @@ describe("advancePlayer", () => {
     };
     const prevPlayer = testState.currentPlayer;
     advancePlayer(testState, defaultConfig.royalFavour, 1);
-    expect(testState.finalPlayer).toBe(prevPlayer);
+    expect(testState.finalPlayer).toEqual(prevPlayer);
   });
   it("Does not trigger end of game if RF and deck is empty", () => {
     const testState = {

--- a/games/hanabi/test/engine/actions.test.ts
+++ b/games/hanabi/test/engine/actions.test.ts
@@ -55,18 +55,19 @@ describe("removeInfoToken", () => {
 });
 
 describe("drawCard", () => {
-  it("Removes card from deck and adds it to current player's hand", () => {
+  it("Removes card from deck and adds it to current player's hand in specified position", () => {
     const testState = { ...startState };
     const prevDeckSize = testState.board.deck.length;
     const prevHandSize = testState.board.hands[testState.currentPlayer].length;
     const topCard = testState.board.deck[0];
-    drawCard(testState);
+    const pos = 2;
+    drawCard(testState, pos);
     expect(testState.board.deck).toHaveLength(prevDeckSize - 1);
     const newHandSize = testState.board.hands[testState.currentPlayer].length;
     expect(newHandSize).toEqual(prevHandSize + 1);
-    expect(
-      testState.board.hands[testState.currentPlayer][newHandSize - 1],
-    ).toEqual(topCard);
+    expect(testState.board.hands[testState.currentPlayer][pos]).toEqual(
+      topCard,
+    );
   });
   it("Adds nothing when drawing from empty deck", () => {
     const testState = {
@@ -74,7 +75,7 @@ describe("drawCard", () => {
       board: { ...startState.board, deck: [] },
     };
     const prevHandSize = testState.board.hands[testState.currentPlayer].length;
-    drawCard(testState);
+    drawCard(testState, 0);
     expect(testState.board.deck.length).toEqual(0);
     const newHandSize = testState.board.hands[testState.currentPlayer].length;
     expect(newHandSize).toEqual(prevHandSize);

--- a/games/hanabi/test/engine/board.test.ts
+++ b/games/hanabi/test/engine/board.test.ts
@@ -1,15 +1,15 @@
 import { isFinished, getInitialBoard } from "../../src/engine/board";
-import { Board, mapToColours } from "../../src/api";
+import { Board, mapToColours, Config } from "../../src/api";
 import { defaultConfig } from "../../src/client";
 import * as _ from "lodash";
 
 describe("isFinished", () => {
-  const basicConfig = {
+  const basicConfig: Config = {
     royalFavour: false,
     ...defaultConfig,
   };
   const board: Board = getInitialBoard(2, defaultConfig);
-  const fullPiles = mapToColours(5);
+  const fullPiles = mapToColours(5, basicConfig.gameType);
   it("returns false for an initial state", () => {
     expect(isFinished(board, 0, basicConfig.royalFavour)).toBeFalsy();
   });
@@ -35,15 +35,15 @@ describe("isFinished", () => {
   });
 
   // Royal Favour variant
-  const rfConfig = {
+  const rfConfig: Config = {
     ...defaultConfig,
     royalFavour: true,
   };
   const rfBoard: Board = getInitialBoard(2, rfConfig);
-  it("returns false for an initial state  in RF", () => {
+  it("returns false for an initial state in RF", () => {
     expect(isFinished(rfBoard, 0, rfConfig.royalFavour)).toBeFalsy();
   });
-  it("return true if all piles have been completed  in RF", () => {
+  it("return true if all piles have been completed in RF", () => {
     expect(
       isFinished({ ...rfBoard, piles: fullPiles }, 0, rfConfig.royalFavour),
     ).toBeTruthy();
@@ -75,6 +75,28 @@ describe("isFinished", () => {
         0,
         rfConfig.royalFavour,
       ),
+    ).toBeTruthy();
+  });
+
+  // Rainbow variant
+  const rainbowConfig: Config = {
+    ...defaultConfig,
+    gameType: "rainbow",
+  };
+  const rainbowBoard: Board = getInitialBoard(2, rainbowConfig);
+  const rainbowFullPiles = mapToColours(5, rainbowConfig.gameType);
+  it("return true if all piles have been completed including rainbow", () => {
+    expect(
+      isFinished(
+        { ...rainbowBoard, piles: rainbowFullPiles },
+        0,
+        rainbowConfig.royalFavour,
+      ),
+    ).toBeTruthy();
+  });
+  it("return true if all piles have been completed including rainbow in RF", () => {
+    expect(
+      isFinished({ ...rainbowBoard, piles: rainbowFullPiles }, 0, true),
     ).toBeTruthy();
   });
 });

--- a/games/hanabi/test/engine/deck.test.ts
+++ b/games/hanabi/test/engine/deck.test.ts
@@ -7,7 +7,7 @@ import {
 import {
   cardsPerNumber,
   getColours,
-  emptyDiscardPile,
+  getEmptyDiscardPile,
   getHandSize,
 } from "../../src/api";
 import * as _ from "lodash";
@@ -18,14 +18,14 @@ describe("createDeck", () => {
     const deck = createDeck(gameType);
     const expectedDeckSize =
       _.sum(Object.values(cardsPerNumber)) * getColours(gameType).length;
-    expect(deck.length).toBe(expectedDeckSize);
+    expect(deck.length).toEqual(expectedDeckSize);
   });
   it("Creates a full deck with rainbow if specified", () => {
     const gameType = "rainbow";
     const deck = createDeck(gameType);
     const expectedDeckSize =
       _.sum(Object.values(cardsPerNumber)) * getColours(gameType).length;
-    expect(deck.length).toBe(expectedDeckSize);
+    expect(deck.length).toEqual(expectedDeckSize);
   });
 });
 
@@ -43,11 +43,11 @@ describe("cannotCompleteSet", () => {
 });
 
 describe("cannotCompleteEverySet", () => {
+  const pile = getEmptyDiscardPile("basic");
   it("Returns false if all sets can still be completed", () => {
-    expect(cannotCompleteEverySet(emptyDiscardPile)).toBeFalsy;
+    expect(cannotCompleteEverySet(pile)).toBeFalsy;
   });
   it("Returns true if a set can not be completed anymore", () => {
-    const pile = emptyDiscardPile;
     pile["red"] = [{ colour: "red", num: 5 }];
     expect(cannotCompleteEverySet(pile)).toBeTruthy;
   });
@@ -60,9 +60,9 @@ describe("deal", () => {
     const startingDeckSize = deck.length;
     const handSize = getHandSize(numPlayers);
     const hands = deal(deck, numPlayers);
-    expect(hands.length).toBe(numPlayers);
-    expect(hands[0].length).toBe(handSize);
-    expect(hands[1].length).toBe(handSize);
-    expect(deck.length).toBe(startingDeckSize - numPlayers * handSize);
+    expect(hands).toHaveLength(numPlayers);
+    expect(hands[0]).toHaveLength(handSize);
+    expect(hands[1]).toHaveLength(handSize);
+    expect(deck).toHaveLength(startingDeckSize - numPlayers * handSize);
   });
 });


### PR DESCRIPTION
- should fix win condition
- address Tom's comment on the colour type
- include a commit that I somehow forgot to push to last PR that indicates the current player more obviously
- indicate token loss/gain more clearly with colour animation
- reorganize discard pile (separate columns for colours)
- draw card into the played position, not to the right
- change font
- make everything a bit more mobile friendly (not perfect but should be playable)


Next: animating/highlighting cards to indicate what happened.